### PR TITLE
Use loadingChild when specified in AsyncElevatedButton on TransitionAnimationType.stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Fixed loadingChild in AsyncElevatedButton when using TransitionAnimationType.stack
+
 ## 0.2.0
 
 * Add support for AsyncIconButton

--- a/lib/src/async_elevated_button.dart
+++ b/lib/src/async_elevated_button.dart
@@ -229,7 +229,8 @@ class _AsyncElevatedButtonState extends State<AsyncElevatedButton> {
                   duration: widget.animationDuration,
                   child: Visibility(
                     visible: _isLoading,
-                    child: _DefaultLoadingIndicator(style: widget.style),
+                    child: widget.loadingChild ??
+                        _DefaultLoadingIndicator(style: widget.style),
                   ),
                 ),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: loadable_buttons
 description: "Provides enhanced buttons with built-in loading states, async functionality and customizable transitions."
-version: 0.2.0
+version: 0.2.1
 homepage: https://hectoraguero.dev/
 repository: https://github.com/hectorAguero/loadable_buttons
 issue_tracker: https://github.com/hectorAguero/loadable_buttons/issues


### PR DESCRIPTION
closes #2 